### PR TITLE
Use svg for build status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# msx [![Build Status](https://secure.travis-ci.org/insin/msx.png?branch=master)](http://travis-ci.org/insin/msx)
+# msx [![Build Status](https://secure.travis-ci.org/insin/msx.svg?branch=master)](http://travis-ci.org/insin/msx)
 
 [React](http://facebook.github.io/react/)'s JSX Transformer, tweaked to output
 calls to [Mithril](http://lhorie.github.io/mithril/)'s `m()` function in the


### PR DESCRIPTION
Hello!

Thanks for making this available.

Just an extremely minor patch here. You see, on my phone these png build icons looks a bit... not so crisp. And seeing as travis now offers svg icons, that would look even better. So if you want, this fixes that.

Other than that, great stuff, thanks. And have a great day!
